### PR TITLE
Mejorar UI con vista de tablero

### DIFF
--- a/src/main/java/com/example/tareas/controller/TareaController.java
+++ b/src/main/java/com/example/tareas/controller/TareaController.java
@@ -21,7 +21,14 @@ public class TareaController {
 
     @GetMapping("/")
     public String listarTareas(Model model) {
-        model.addAttribute("tareas", tareas);
+        List<Tarea> pendientes = tareas.stream()
+                .filter(t -> !t.isCompletada())
+                .toList();
+        List<Tarea> completadas = tareas.stream()
+                .filter(Tarea::isCompletada)
+                .toList();
+        model.addAttribute("pendientes", pendientes);
+        model.addAttribute("completadas", completadas);
         return "tareas";
     }
 
@@ -38,6 +45,17 @@ public class TareaController {
         for (Tarea t : tareas) {
             if (t.getId() == id) {
                 t.setCompletada(true);
+                break;
+            }
+        }
+        return "redirect:/";
+    }
+
+    @PostMapping("/incompletar/{id}")
+    public String incompletarTarea(@PathVariable("id") long id) {
+        for (Tarea t : tareas) {
+            if (t.getId() == id) {
+                t.setCompletada(false);
                 break;
             }
         }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,40 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f6f7fb;
+    margin: 0;
+}
+header {
+    background-color: #1a73e8;
+    color: white;
+    padding: 1rem;
+}
+header form {
+    margin-top: 1rem;
+}
+.board {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem;
+}
+.column {
+    flex: 1;
+    background-color: #fff;
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.column h2 {
+    margin-top: 0;
+}
+.tarea {
+    background-color: #f1f3f4;
+    border-radius: 4px;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.tarea form {
+    display: inline;
+}
+.tarea button {
+    margin-left: 0.5rem;
+}

--- a/src/main/resources/templates/tareas.html
+++ b/src/main/resources/templates/tareas.html
@@ -2,32 +2,42 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8"/>
-    <title>Lista de Tareas</title>
+    <title>Tablero de Tareas</title>
+    <link rel="stylesheet" th:href="@{/style.css}">
 </head>
 <body>
-<h1>Lista de Tareas</h1>
-<form th:action="@{/agregar}" method="post">
-    <input type="text" name="descripcion" placeholder="Nueva tarea" required/>
-    <button type="submit">Agregar</button>
-</form>
-<table border="1">
-    <tr>
-        <th>Descripción</th>
-        <th>Completada</th>
-        <th>Acciones</th>
-    </tr>
-    <tr th:each="tarea : ${tareas}">
-        <td th:text="${tarea.descripcion}"></td>
-        <td th:text="${tarea.completada} ? 'Sí' : 'No'"></td>
-        <td>
-            <form th:action="@{/completar/{id}(id=${tarea.id})}" method="post" th:if="${!tarea.completada}" style="display:inline">
+<header>
+    <h1>Tablero de Tareas</h1>
+    <form th:action="@{/agregar}" method="post">
+        <input type="text" name="descripcion" placeholder="Nueva tarea" required/>
+        <button type="submit">Agregar</button>
+    </form>
+</header>
+<div class="board">
+    <div class="column">
+        <h2>Pendientes</h2>
+        <div th:each="tarea : ${pendientes}" class="tarea">
+            <span th:text="${tarea.descripcion}"></span>
+            <form th:action="@{/completar/{id}(id=${tarea.id})}" method="post">
                 <button type="submit">Completar</button>
             </form>
-            <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post" style="display:inline">
+            <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
                 <button type="submit">Eliminar</button>
             </form>
-        </td>
-    </tr>
-</table>
+        </div>
+    </div>
+    <div class="column">
+        <h2>Completadas</h2>
+        <div th:each="tarea : ${completadas}" class="tarea">
+            <span th:text="${tarea.descripcion}"></span>
+            <form th:action="@{/incompletar/{id}(id=${tarea.id})}" method="post">
+                <button type="submit">Marcar pendiente</button>
+            </form>
+            <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
+                <button type="submit">Eliminar</button>
+            </form>
+        </div>
+    </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create board layout with two columns for pending and completed tasks
- add endpoint to revert task completion
- style page similar to a board using a new CSS file

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420ea82210832fa6f8e95264c36064