### PR TITLE
Improve task styling with checkboxes

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -7,9 +7,45 @@ header {
     background-color: #1a73e8;
     color: white;
     padding: 1rem;
+    position: relative;
+    overflow: hidden;
 }
 header form {
     margin-top: 1rem;
+}
+header .header-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    fill: #0b5ed7;
+    opacity: 0.3;
+    z-index: 0;
+}
+header h1,
+header form {
+    position: relative;
+    z-index: 1;
+}
+.icon-button {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+.tarea-form {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.tarea-form input[type="checkbox"] {
+    accent-color: #1a73e8;
+}
+.tarea-form input[type="checkbox"]:checked + span {
+    text-decoration: line-through;
+    color: #a0a0a0;
 }
 .board {
     display: flex;
@@ -31,10 +67,4 @@ header form {
     border-radius: 4px;
     padding: 0.5rem;
     margin-bottom: 0.5rem;
-}
-.tarea form {
-    display: inline;
-}
-.tarea button {
-    margin-left: 0.5rem;
 }

--- a/src/main/resources/templates/tareas.html
+++ b/src/main/resources/templates/tareas.html
@@ -7,19 +7,22 @@
 </head>
 <body>
 <header>
+    <svg class="header-bg" viewBox="0 0 100 20" preserveAspectRatio="none">
+        <path d="M0 20 L100 0 L100 20 Z"/>
+    </svg>
     <h1>Tablero de Tareas</h1>
-    <form th:action="@{/agregar}" method="post">
+    <form th:action="@{/agregar}" method="post" class="add-form">
         <input type="text" name="descripcion" placeholder="Nueva tarea" required/>
-        <button type="submit">Agregar</button>
+        <button type="submit" class="icon-button">+</button>
     </form>
 </header>
 <div class="board">
     <div class="column">
         <h2>Pendientes</h2>
         <div th:each="tarea : ${pendientes}" class="tarea">
-            <span th:text="${tarea.descripcion}"></span>
-            <form th:action="@{/completar/{id}(id=${tarea.id})}" method="post">
-                <button type="submit">Completar</button>
+            <form th:action="@{/completar/{id}(id=${tarea.id})}" method="post" class="tarea-form">
+                <input type="checkbox" onchange="this.form.submit()"/>
+                <span th:text="${tarea.descripcion}"></span>
             </form>
             <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
                 <button type="submit">Eliminar</button>
@@ -29,9 +32,9 @@
     <div class="column">
         <h2>Completadas</h2>
         <div th:each="tarea : ${completadas}" class="tarea">
-            <span th:text="${tarea.descripcion}"></span>
-            <form th:action="@{/incompletar/{id}(id=${tarea.id})}" method="post">
-                <button type="submit">Marcar pendiente</button>
+            <form th:action="@{/incompletar/{id}(id=${tarea.id})}" method="post" class="tarea-form">
+                <input type="checkbox" checked onchange="this.form.submit()"/>
+                <span th:text="${tarea.descripcion}"></span>
             </form>
             <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
                 <button type="submit">Eliminar</button>


### PR DESCRIPTION
## Summary
- add SVG wave to header
- replace add button with an icon
- use checkboxes to mark tasks complete
- style completed tasks with line-through and pale color

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684210b4c0bc832fa73e581332cad743