### PR TITLE
Add Materialize style and inline editing

### DIFF
--- a/src/main/java/com/example/tareas/controller/TareaController.java
+++ b/src/main/java/com/example/tareas/controller/TareaController.java
@@ -21,14 +21,7 @@ public class TareaController {
 
     @GetMapping("/")
     public String listarTareas(Model model) {
-        List<Tarea> pendientes = tareas.stream()
-                .filter(t -> !t.isCompletada())
-                .toList();
-        List<Tarea> completadas = tareas.stream()
-                .filter(Tarea::isCompletada)
-                .toList();
-        model.addAttribute("pendientes", pendientes);
-        model.addAttribute("completadas", completadas);
+        model.addAttribute("tareas", tareas);
         return "tareas";
     }
 
@@ -40,22 +33,23 @@ public class TareaController {
         return "redirect:/";
     }
 
-    @PostMapping("/completar/{id}")
-    public String completarTarea(@PathVariable("id") long id) {
+    @PostMapping("/toggle/{id}")
+    public String toggleTarea(@PathVariable("id") long id) {
         for (Tarea t : tareas) {
             if (t.getId() == id) {
-                t.setCompletada(true);
+                t.setCompletada(!t.isCompletada());
                 break;
             }
         }
         return "redirect:/";
     }
 
-    @PostMapping("/incompletar/{id}")
-    public String incompletarTarea(@PathVariable("id") long id) {
+    @PostMapping("/editar/{id}")
+    public String editarTarea(@PathVariable("id") long id,
+                              @RequestParam("descripcion") String descripcion) {
         for (Tarea t : tareas) {
             if (t.getId() == id) {
-                t.setCompletada(false);
+                t.setDescripcion(descripcion);
                 break;
             }
         }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,70 +1,17 @@
 body {
     font-family: Arial, sans-serif;
-    background-color: #f6f7fb;
     margin: 0;
 }
-header {
-    background-color: #1a73e8;
-    color: white;
-    padding: 1rem;
-    position: relative;
-    overflow: hidden;
+
+.circle {
+    border-radius: 50%;
 }
-header form {
-    margin-top: 1rem;
-}
-header .header-bg {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    fill: #0b5ed7;
-    opacity: 0.3;
-    z-index: 0;
-}
-header h1,
-header form {
-    position: relative;
-    z-index: 1;
-}
-.icon-button {
-    background: none;
-    border: none;
-    color: white;
-    font-size: 1.5rem;
-    cursor: pointer;
-}
-.tarea-form {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-.tarea-form input[type="checkbox"] {
-    accent-color: #1a73e8;
-}
-.tarea-form input[type="checkbox"]:checked + span {
+
+.tarea-item.completed .tarea-text {
     text-decoration: line-through;
-    color: #a0a0a0;
+    color: #9e9e9e;
 }
-.board {
-    display: flex;
-    gap: 1rem;
-    padding: 1rem;
-}
-.column {
-    flex: 1;
-    background-color: #fff;
-    border-radius: 8px;
-    padding: 1rem;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-.column h2 {
-    margin-top: 0;
-}
-.tarea {
-    background-color: #f1f3f4;
-    border-radius: 4px;
-    padding: 0.5rem;
-    margin-bottom: 0.5rem;
+
+.tarea-text {
+    cursor: pointer;
 }

--- a/src/main/resources/templates/tareas.html
+++ b/src/main/resources/templates/tareas.html
@@ -3,44 +3,54 @@
 <head>
     <meta charset="UTF-8"/>
     <title>Tablero de Tareas</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" th:href="@{/style.css}">
 </head>
-<body>
-<header>
-    <svg class="header-bg" viewBox="0 0 100 20" preserveAspectRatio="none">
-        <path d="M0 20 L100 0 L100 20 Z"/>
-    </svg>
-    <h1>Tablero de Tareas</h1>
-    <form th:action="@{/agregar}" method="post" class="add-form">
-        <input type="text" name="descripcion" placeholder="Nueva tarea" required/>
-        <button type="submit" class="icon-button">+</button>
-    </form>
-</header>
-<div class="board">
-    <div class="column">
-        <h2>Pendientes</h2>
-        <div th:each="tarea : ${pendientes}" class="tarea">
-            <form th:action="@{/completar/{id}(id=${tarea.id})}" method="post" class="tarea-form">
-                <input type="checkbox" onchange="this.form.submit()"/>
-                <span th:text="${tarea.descripcion}"></span>
-            </form>
-            <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
-                <button type="submit">Eliminar</button>
-            </form>
-        </div>
+<body class="grey lighten-4">
+<nav class="blue">
+    <div class="nav-wrapper container">
+        <span class="brand-logo">Tablero de Tareas</span>
+        <form th:action="@{/agregar}" method="post" class="right">
+            <div class="input-field inline">
+                <input id="nuevaTarea" type="text" name="descripcion" placeholder="Nueva tarea" required>
+            </div>
+            <button type="submit" class="btn-floating waves-effect waves-light">
+                <i class="material-icons">add</i>
+            </button>
+        </form>
     </div>
-    <div class="column">
-        <h2>Completadas</h2>
-        <div th:each="tarea : ${completadas}" class="tarea">
-            <form th:action="@{/incompletar/{id}(id=${tarea.id})}" method="post" class="tarea-form">
-                <input type="checkbox" checked onchange="this.form.submit()"/>
-                <span th:text="${tarea.descripcion}"></span>
+</nav>
+<div class="container">
+    <ul class="collection" th:each="tarea : ${tareas}">
+        <li class="collection-item avatar tarea-item" th:classappend="${tarea.completada}? 'completed' : ''">
+            <form th:action="@{/toggle/{id}(id=${tarea.id})}" method="post" class="left">
+                <label>
+                    <input type="checkbox" class="filled-in circle" th:checked="${tarea.completada}" onchange="this.form.submit()" />
+                    <span></span>
+                </label>
             </form>
-            <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
-                <button type="submit">Eliminar</button>
+            <span th:text="${tarea.descripcion}" onclick="enableEdit(this, [[${tarea.id}]])" class="tarea-text"></span>
+            <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post" class="secondary-content">
+                <button type="submit" class="btn-flat"><i class="material-icons red-text">delete</i></button>
             </form>
-        </div>
-    </div>
+        </li>
+    </ul>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+<script>
+function enableEdit(span, id) {
+    span.contentEditable = true;
+    span.focus();
+    span.onblur = function() {
+        span.contentEditable = false;
+        fetch('/editar/' + id, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: 'descripcion=' + encodeURIComponent(span.textContent)
+        }).then(() => { window.location.reload(); });
+    };
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- unify pending and completed tasks in controller
- add endpoints to toggle completion and edit tasks
- modernize HTML using Materialize
- style round checkboxes and completed tasks

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684213141c78832fa0241ca199bebd8b