### PR TITLE
Add edit button to tasks list

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -52,3 +52,7 @@ body {
     flex: 1;
     margin: 0 10px;
 }
+
+.edit-btn {
+    margin-right: 5px;
+}

--- a/src/main/resources/templates/tareas.html
+++ b/src/main/resources/templates/tareas.html
@@ -29,7 +29,10 @@
                     <span></span>
                 </label>
             </form>
-            <span th:text="${tarea.descripcion}" onclick="enableEdit(this, [[${tarea.id}]])" class="tarea-text"></span>
+            <span th:text="${tarea.descripcion}" class="tarea-text" onclick="enableEdit(this, [[${tarea.id}]])"></span>
+            <button type="button" class="btn-flat edit-btn" onclick="enableEdit(this.previousElementSibling, [[${tarea.id}]])">
+                <i class="material-icons grey-text text-darken-2">edit</i>
+            </button>
             <form th:action="@{/eliminar/{id}(id=${tarea.id})}" method="post">
                 <button type="submit" class="btn-flat"><i class="material-icons grey-text text-darken-2">delete</i></button>
             </form>


### PR DESCRIPTION
## Summary
- let users edit tasks using a dedicated button

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684216e3eb48832f824f5c542493dce9